### PR TITLE
Feature/6 make cookies available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,13 @@ deploy:
     skip_cleanup: true
     on:
       repo: SOBotics/chatexchange
+      branch: develop
+      jdk: oraclejdk8
+  -
+    provider: script
+    script: .travis/deploy.sh
+    skip_cleanup: true
+    on:
+      repo: SOBotics/chatexchange
       tags: true
       jdk: oraclejdk8

--- a/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
@@ -31,5 +31,17 @@ public enum ChatHost {
 	public String getBaseUrl() {
 		return baseUrl;
 	}
+	
+	/**
+	 * Compares the host to another object
+	 * @param otherHost other object
+	 * @return true, if the name is the same
+	 */
+	public boolean equals(ChatHost otherHost) {
+		if (otherHost == null)
+			return false;
+		
+		return this.name.equals(otherHost.name);
+	}
 
 }

--- a/src/main/java/org/sobotics/chatexchange/chat/Room.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/Room.java
@@ -618,6 +618,14 @@ public final class Room {
 	public ChatHost getHost() {
 		return host;
 	}
+	
+	/**
+	 * Returns the cookies used to post in this room
+	 * @return cookies as Map
+	 */
+	public Map<String, String> getCookies() {
+		return this.cookies;
+	}
 
 	void close() {
 		executor.shutdown();

--- a/src/main/java/org/sobotics/chatexchange/chat/StackExchangeClient.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/StackExchangeClient.java
@@ -246,6 +246,14 @@ public class StackExchangeClient implements AutoCloseable {
 	public void setAutoCreateAccount(boolean autoCreateAccount) {
 		this.autoCreateAccount = autoCreateAccount;
 	}
+	
+	/**
+	 * Returns the cookies the library uses
+	 * @return Cookies
+	 */
+	public Map<String, String> getCookies() {
+		return this.cookies;
+	}
 
 	/**
 	 * Closes this client by making the logged-in user leave all the chat rooms they joined.

--- a/src/main/java/org/sobotics/chatexchange/chat/StackExchangeClient.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/StackExchangeClient.java
@@ -247,12 +247,22 @@ public class StackExchangeClient implements AutoCloseable {
 		this.autoCreateAccount = autoCreateAccount;
 	}
 	
+	
 	/**
-	 * Returns the cookies the library uses
-	 * @return Cookies
+	 * Returns the cookies for the first room with the given host
+	 * @param host {@link ChatHost} to search for
+	 * @return null, if no room with the given {@link ChatHost} was found
 	 */
-	public Map<String, String> getCookies() {
-		return this.cookies;
+	public Map<String, String> getCookies(ChatHost host) {
+		for (Room room : this.rooms) {
+			ChatHost roomHost = room.getHost();
+			
+			if (host.equals(roomHost)) {
+				return room.getCookies();
+			}
+		}
+		
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Added methods to get the cookies, chatexchange is using:

`StackExchangeClient.getCookies(ChatRoom)` and `Room.getCookies()`


You can use `2.1.0-SNAPSHOT` to test this

---

closes #6 