### PR TITLE
#4: + more detailed exceptions

### DIFF
--- a/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
@@ -12,10 +12,24 @@ public enum ChatHost {
 	META_STACK_EXCHANGE("meta.stackexchange.com");
 
 	private final String name, baseUrl;
+	
+	/**
+	 * Host that is used for the login
+	 * 
+	 * This might be a different host, because stackexchange.com does not have a login
+	 */
+	private final String loginHost;
 
 	private ChatHost(String name) {
 		this.name = name;
 		this.baseUrl = "https://chat." + name;
+		
+		if (this.name.equalsIgnoreCase("stackexchange.com")) {
+			//stackexchange.com doesn't have a login, so we have to use meta
+			this.loginHost = "meta.stackexchange.com";
+		} else {
+			this.loginHost = this.name;
+		}
 	}
 
 	/**
@@ -30,6 +44,13 @@ public enum ChatHost {
 	 */
 	public String getBaseUrl() {
 		return baseUrl;
+	}
+	
+	/**
+	 * @return Host that is used for the login
+	 */
+	public String getLoginHost() {
+		return this.loginHost;
 	}
 
 }

--- a/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/ChatHost.java
@@ -51,9 +51,9 @@ public enum ChatHost {
 	 */
 	public String getLoginHost() {
 		return this.loginHost;
-  }
+    }
   
-  
+    /**
 	 * Compares the host to another object
 	 * @param otherHost other object
 	 * @return true, if the name is the same

--- a/src/main/java/org/sobotics/chatexchange/chat/ChatLoginException.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/ChatLoginException.java
@@ -1,0 +1,49 @@
+package org.sobotics.chatexchange.chat;
+
+/**
+ * Exception when the login fails. Contains information about the hosts
+ * 
+ * @author FelixSFD
+ */
+public class ChatLoginException extends Exception {
+	private static final long serialVersionUID = 3836431112726533617L;
+	
+	/**
+	 * {@link ChatHost} that was used for the login
+	 */
+	private ChatHost host;
+	
+	/**
+	 * Initializes the exception
+	 * @param chatHost {@link ChatHost} that was used for the login
+	 * @param message Error-message
+	 */
+	public ChatLoginException(ChatHost chatHost, String message) {
+		super(message);
+		this.host = chatHost;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getMessage() {
+		String msg = "Unable to login to " + this.host.getName();
+		
+		if (!this.host.getName().equalsIgnoreCase(this.host.getLoginHost())) {
+			msg += " (via " + this.host.getLoginHost() + ")";
+		}
+		
+		msg += ": " + super.getMessage();
+		
+		return msg;
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getLocalizedMessage() {
+		return this.getMessage();
+	}
+}


### PR DESCRIPTION
## Enhanced `ChatHost`

New property `loginHost`, which contains the host that is used for the login, since it might be different from the `name`-property when using chat.stackexchange.com

## New Exception `ChatLoginException`

This contains the reason why the login failed and the `ChatHost`-object.

---

closes #4 