### PR TITLE
Bump Tyrus to a new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.glassfish.tyrus.bundles</groupId>
 			<artifactId>tyrus-standalone-client-jdk</artifactId>
-			<version>1.13.1</version>
+			<version>2.1.5</version>
 		</dependency>
 	</dependencies>
 	<licenses>

--- a/src/main/java/org/sobotics/chatexchange/chat/Room.java
+++ b/src/main/java/org/sobotics/chatexchange/chat/Room.java
@@ -35,14 +35,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import javax.websocket.ClientEndpointConfig;
-import javax.websocket.ClientEndpointConfig.Builder;
-import javax.websocket.ClientEndpointConfig.Configurator;
-import javax.websocket.DeploymentException;
-import javax.websocket.Endpoint;
-import javax.websocket.EndpointConfig;
-import javax.websocket.Session;
-
+import jakarta.websocket.*;
 import org.glassfish.tyrus.client.ClientManager;
 import org.glassfish.tyrus.client.ClientProperties;
 import org.glassfish.tyrus.container.jdk.client.JdkClientContainer;
@@ -187,8 +180,8 @@ public final class Room {
 		}
 		LOGGER.debug("Connecting to chat WebSocket at URL {} for room {}", websocketUrl, roomId);
 		ClientManager client = ClientManager.createClient(JdkClientContainer.class.getName());
-		Builder configBuilder = ClientEndpointConfig.Builder.create();
-		configBuilder.configurator(new Configurator() {
+		ClientEndpointConfig.Builder configBuilder = ClientEndpointConfig.Builder.create();
+		configBuilder.configurator(new ClientEndpointConfig.Configurator() {
 			@Override
 			public void beforeRequest(Map<String, List<String>> headers) {
 				headers.put("Origin", Arrays.asList(hostUrlBase));


### PR DESCRIPTION
<!-- Please don't forget to list the tickets, you wan't to close with this PR like this: fixed #[issue number] -->
<!-- For larger changes, please give a detailed description of what your code is doing. Also: Don't forget commenting your code! -->

For reasons I'm not going to pretend to understand, bumping the Tyrus client from 1.13.1 to 2.1.5 fixes a bug that prevents both GenericBot and Natty from connecting to chat.

For context, debugging (and related error messages) start [here](https://chat.stackoverflow.com/transcript/message/57396845#57396845)
